### PR TITLE
Handle existing JA response (code 422) with new custom error

### DIFF
--- a/jobapplications.go
+++ b/jobapplications.go
@@ -95,6 +95,11 @@ func (t TeamTailor) CreateJobApplication(idjob string, idcand string) (JobApplic
 	if err != nil {
 		return ja, err
 	}
+
+	if resp.StatusCode == 422 {
+		return ja, errors.New("job-application for candidate and position already exist")
+	}
+
 	if resp.StatusCode != 201 {
 		return ja, errors.New("Failed to create job application")
 	}


### PR DESCRIPTION
When trying to create a new job-application that already exist (i.e. the combination of candidate and position is already present), the package will respond with a custom error signifying specifically this event.